### PR TITLE
Changes for v0.4.0

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -72,3 +72,12 @@ Currently, `runbook run` supports the execution of `bash`, `javascript`, `typesc
 `runbook` expects the required runtime to be installed on the current system. In the future, `runbook` will automatically download and use runtimes that are not already installed locally.
 
 More runtimes are coming soon!
+
+## external content
+
+Rather than embedded some code or a script inside a markdown fenced code block in the document, a block can reference its contents by pointing to a local file that is external to the document.
+
+The following block uses a `file://` reference to load its contents from a local file.
+
+```typescript "hello from an external file" file://src/features/hello.ts
+```

--- a/USAGE.md
+++ b/USAGE.md
@@ -81,3 +81,12 @@ The following block uses a `file://` reference to load its contents from a local
 
 ```typescript "hello from an external file" file://src/features/hello.ts
 ```
+
+## calling other scripts
+
+A runbook script written in `bash` can easily call other runbook scripts.
+
+```bash "calling other scripts"
+runbook run hello
+runbook run hello --greeting "Hey there" --name "Jim"
+```

--- a/USAGE.md
+++ b/USAGE.md
@@ -61,10 +61,11 @@ func main() {
 
 ## supported runtimes
 
-Currently, `runbook run` supports the execution of `bash`, `javascript`, `python`, and `go` blocks. Other blocks are ignored.
+Currently, `runbook run` supports the execution of `bash`, `javascript`, `typescript`, `python`, and `go` blocks. Other blocks are ignored.
 
 - `bash` blocks are executed with `bash`
 - `javascript` and `js` blocks are executed with `node`
+- `typescript` and `ts` blocks are executed with `npx ts-node`
 - `python` blocks are executed with `python`
 - `go` blocks are executed with `go`
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test": "mocha -r ts-node/register src/**/*.test.ts"
   },
   "files": [
-    "dist/"
+    "dist/",
+    "USAGE.md"
   ],
   "dependencies": {
     "chalk": "^4.1.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,19 +1,14 @@
 #!/usr/bin/env node
 
-import { ls, run } from './index'
-import colors from './features/colors'
+import { help, ls, run } from './index'
 import { ApplicationError } from './features/errors'
 
 async function cli (args: string[]) {
   const command = args.shift()
   if (command === 'ls') return ls()
   if (command === 'run' && args.length > 0) return run(args)
-  if (command === undefined) {
-    console.info()
-    console.info(colors.blue('📂 ls') + '  | ' + colors.yellow('Lists all commands found in documents in the current directory.'))
-    console.info(colors.blue('🚀 run') + ' | ' + colors.yellow('Runs the specified command.'))
-    console.info()
-  }
+  if (command === 'help') return help()
+  if (command === undefined) help()
   throw new ApplicationError('Invalid command')
 }
 

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,0 +1,9 @@
+import colors from '../features/colors'
+
+export function help (options = { log: true }): string {
+  const message = '\n' +
+    colors.blue('📂 ls') + '  | ' + colors.yellow('Lists all commands found in documents in the current directory.') + '\n' +
+    colors.blue('🚀 run') + ' | ' + colors.yellow('Runs the specified command.') + '\n'
+  if (options.log) console.info(message)
+  return message
+}

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -38,7 +38,8 @@ export async function ls (options = { log: true, rules: true }) {
   return markdownFiles
 }
 
-function normalizedLang (block: { lang?: string }) {
+function normalizedLang (block: { lang?: string }): string | undefined {
   if (block.lang === 'js') return 'javascript'
+  if (block.lang === 'ts') return 'typescript'
   return block.lang
 }

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -1,4 +1,5 @@
 import { dirname, resolve } from 'path'
+import type { Position } from 'unist'
 
 import files from '../features/files'
 import markdown from '../features/markdown'
@@ -12,27 +13,26 @@ export async function ls (options = { log: true, rules: true }) {
   const markdownFiles = await files.discover(['*.md'])
     .then(paths => Promise.all(paths.map(async path => ({ path, content: await files.read(path, 'utf-8') }))))
     .then(files => files.map(file => ({ ...file, blocks: markdown.blocks(file.content) })))
-    .then(files => files.map(file => {
+    .then(files => Promise.all(files.map(async file => {
       return {
         ...file,
-        commands: file.blocks.filter(block => (block.lang === 'bash' || block.lang === 'hbs' || block.lang === 'python' || block.lang === 'go' || normalizedLang(block) === 'javascript') && block.meta?.includes('"')).map(block => {
-          const names = block.meta?.match(/"([^"]*)"/g)
-          if (names?.length !== 1) throw new ApplicationError(`[${file.path}:${block.position?.start.line}] A code block must have exactly one name`)
-          const name = names[0].substring(1, names[0].length - 1)
-          const args = handlebars.args(block.value)
+        commands: await Promise.all(file.blocks.filter(block => isSupportedBlock({ block }) && block.meta?.includes('"')).map(async block => {
+          const name = getBlockName({ file, block })
+          const content = await getBlockContent({ file, block })
+          const { args, template } = getBlockArgs({ block, content })
           if (options.log) console.info(file.path, '|', colors.green(name), args.map(arg => `--${arg}`).join(' '))
           return {
             name,
             lang: normalizedLang(block),
             position: block.position,
-            script: block.value,
+            script: content,
             cwd: dirname(resolve(file.path)),
-            template: (block.lang === 'hbs' || block.meta?.startsWith('hbs')) ? handlebars.template(block.value) : undefined,
-            args: (block.lang === 'hbs' || block.meta?.startsWith('hbs')) ? args : undefined
+            template,
+            args
           }
-        })
+        }))
       }
-    }))
+    })))
   if (markdownFiles.length === 0) throw new ApplicationError(`No markdown files found in ${process.cwd()}`)
   if (options.rules) ensureUniqueBlockSignatures(markdownFiles)
   return markdownFiles
@@ -42,4 +42,34 @@ function normalizedLang (block: { lang?: string }): string | undefined {
   if (block.lang === 'js') return 'javascript'
   if (block.lang === 'ts') return 'typescript'
   return block.lang
+}
+
+function isSupportedBlock (params: { block: { lang?: string }}): boolean {
+  const lang = normalizedLang(params.block)
+  return (lang === 'bash' || lang === 'hbs' || lang === 'javascript' || lang === 'typescript' || lang === 'python' || lang === 'go')
+}
+
+function getBlockName (params: { file: { path: string }, block: { meta?: string, position?: Position } }): string {
+  const names = params.block.meta?.match(/"([^"]*)"/g)
+  if (names?.length !== 1) throw new ApplicationError(`[${params.file.path}:${params.block.position?.start.line}] A code block must have exactly one name`)
+  const name = names[0].substring(1, names[0].length - 1)
+  return name
+}
+
+async function getBlockContent (params: { file: { path: string }, block: { meta?: string, position?: Position, value: string }}): Promise<string> {
+  const paths = params.block.meta?.match(/(file):\/\/(.+)/g)
+  if (!paths || paths.length === 0) return params.block.value
+  if (paths.length !== 1) throw new ApplicationError(`[${params.file.path}:${params.block.position?.start.line}] A code block can specify only one file path`)
+  if (params.block.value.trim()) throw new ApplicationError(`[${params.file.path}:${params.block.position?.start.line}] A code block that specifies a file path must be empty`)
+  const path = paths[0].substring('file://'.length)
+  return await files.read(path, 'utf-8')
+}
+
+function getBlockArgs (params: { block: { meta?: string, lang?: string }, content: string }): { args: string[], template?: ReturnType<typeof handlebars.template> } {
+  if (params.block.lang === 'hbs' || params.block.meta?.startsWith('hbs')) {
+    const args = handlebars.args(params.content)
+    const template = handlebars.template(params.content)
+    return { args, template }
+  }
+  return { args: [], template: undefined }
 }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -22,7 +22,7 @@ export async function run (args: string[]) {
       // todo: may be better to use yargs for everything instead. also even for command syntax in blocks.
       // todo: ensure destructuring only grabs the options (so passing the options to the template later below doesn't introduce undefined behavior)
       const { _, $0, ...options } = argv
-      if (command.args?.some(arg => !argv[arg]) || Object.keys(options).some(option => !command.args?.includes(option))) {
+      if (command.args.some(arg => !argv[arg]) || Object.keys(options).some(option => !command.args.includes(option))) {
         suggestions.push({ file: { path: file.path }, command })
         continue
       }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -30,6 +30,9 @@ export async function run (args: string[]) {
         if (!shell.which('bash')) throw new ApplicationError(`[${file.path}:${command.position?.start.line}] Could not find "bash" on this system`)
       } else if (command.lang === 'javascript') {
         if (!shell.which('node')) throw new ApplicationError(`[${file.path}:${command.position?.start.line}] Could not find "node" on this system`)
+      } else if (command.lang === 'typescript') {
+        if (!shell.which('node')) throw new ApplicationError(`[${file.path}:${command.position?.start.line}] Could not find "node" on this system`)
+        if (!shell.which('npx')) throw new ApplicationError(`[${file.path}:${command.position?.start.line}] Could not find "npx" on this system`)
       } else if (command.lang === 'python') {
         if (!shell.which('python')) throw new ApplicationError(`[${file.path}:${command.position?.start.line}] Could not find "python" on this system`)
       } else if (command.lang === 'go') {
@@ -44,6 +47,7 @@ export async function run (args: string[]) {
       try {
         if (command.lang === 'bash' || command.lang === 'hbs') execFileSync(resolve(executableFileName), { stdio: 'inherit' })
         else if (command.lang === 'javascript') execFileSync('node', [ executableFileName ], { stdio: 'inherit' })
+        else if (command.lang === 'typescript') execFileSync('npx', [ 'ts-node', executableFileName ], { stdio: 'inherit' })
         else if (command.lang === 'python') execFileSync('python', [ executableFileName ], { stdio: 'inherit' })
         else if (command.lang === 'go') execFileSync('go', [ 'run', executableFileName ], { stdio: 'inherit' })
         else throw new ApplicationError(`[${file.path}:${command.position?.start.line}] Unsupported block language (not executable): ${command.lang}`)

--- a/src/features/hello.ts
+++ b/src/features/hello.ts
@@ -1,0 +1,1 @@
+console.log('Hello from an external file!')

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
+export { help } from './commands/help'
 export { ls } from './commands/ls'
 export { run } from './commands/run'


### PR DESCRIPTION
### Fixes

- Adding USAGE.md to files published to npm, since it is linked by the README
- Adding an example of a script that calls other runbook scripts
- Removing all "todo" comments and comments that are notes

### Features

- A block can now specify its content from an external file, rather than embedding the content in a fenced markdown code block in the document
- Adding support for executing typescript and typescript hbs blocks
- Adding a separate help command