### PR TITLE
Changes for v0.6.0

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,0 +1,40 @@
+# developers
+
+This document is for developers working on the runbook application *itself*. If you're interested in using runbook, see the [README](README.md).
+
+To run without building first, use:
+
+```bash "runbook ls"
+npx ts-node src/cli.ts ls  # or any other runbook command
+```
+
+To quickly test while developing this package, run:
+
+```bash "runbook run hello"
+npx ts-node src/cli.ts run hello --greeting Hey --name Batman
+```
+
+Alternatively, the package can be linked and run with the `DEV=true` environment variable to pick up the latest TypeScript source changes without the need to re-link the package.
+
+```bash "link"
+npm link
+DEV=true runbook run hello --greeting Hey --name Batman
+```
+
+Here's some fun - using runbook to run runbook to run the raw TypeScript version of runbook to run the "hello" command.
+
+```bash "runbook inception"
+runbook run runbook run hello
+```
+
+To run all test cases:
+
+```bash "test"
+npm run test
+```
+
+Here is a command that always fails (useful for seeing how runbook handles errors):
+
+```bash "this will fail"
+exit 1
+```

--- a/LIBRARY.md
+++ b/LIBRARY.md
@@ -3,3 +3,47 @@
 A useful library of various scripts that can be ran with the `runbook` CLI.
 
 Make your own library by [installing runbook](README.md#quickstart) and writing your first runnable markdown file!
+
+## networking
+
+**Which process is using a specific port?**
+
+```bash hbs "which process is using"
+lsof -i tcp:{{ port }}
+```
+
+## encoding
+
+**Encoding a string to a base64 string**
+
+```javascript hbs "encode base64"
+console.log(Buffer.from('{{ input }}', 'utf8').toString('base64'))
+```
+
+**Decoding a base64 string to the original string**
+
+```javascript hbs "decode base64"
+console.log(Buffer.from('{{ input }}', 'base64').toString('utf8'))
+```
+
+## security
+
+**Generate a random password**
+
+```bash "generate password"
+runbook run generate password --length 20
+```
+
+```javascript hbs "generate password"
+const { randomFillSync } = require('crypto')
+
+const generatePassword = (
+  length = {{ length }},
+  wishlist = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz~!@-#$'
+) => Array
+  .from(randomFillSync(new Uint32Array(length)))
+  .map(x => wishlist[x % wishlist.length])
+  .join('')
+
+console.log(generatePassword())
+```

--- a/LIBRARY.md
+++ b/LIBRARY.md
@@ -47,3 +47,25 @@ const generatePassword = (
 
 console.log(generatePassword())
 ```
+
+## fun
+
+**Runbook logo party**
+
+```bash "runbook logo party"
+runbook run print runbook logo --times 3
+```
+
+Prints the runbook logo X times to the terminal.
+
+```es6 hbs "print runbook logo"
+import terminal from './src/features/terminal'
+
+function print (times: number) {
+  for (let i = 0; i < times; i++) {
+    console.log(terminal.ascii.art.logo)
+  }
+}
+
+print({{ times }})
+```

--- a/LIBRARY.md
+++ b/LIBRARY.md
@@ -1,0 +1,5 @@
+# library
+
+A useful library of various scripts that can be ran with the `runbook` CLI.
+
+Make your own library by [installing runbook](README.md#quickstart) and writing your first runnable markdown file!

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install -g @khalidx/runbook
 
 The [USAGE.md](./USAGE.md) file is a runnable markdown document. Check it for some usage examples.
 
-<img src="https://raw.githubusercontent.com/khalidx/runbook/main/img/screenshot.png" alt="Runbook - Command Line Interface Screenshot" width="450px">
+<img src="https://raw.githubusercontent.com/khalidx/runbook/main/img/screenshot.png" alt="Runbook - Command Line Interface Screenshot" width="800px">
 
 ## commands
 

--- a/README.md
+++ b/README.md
@@ -91,41 +91,4 @@ Shows what you can do with the `runbook` CLI.
 
 Open a GitHub issue to report a bug or request a feature!
 
-*For Developers*
-
-To run without building first, use:
-
-```bash "runbook ls"
-npx ts-node src/cli.ts ls  # or any other runbook command
-```
-
-To quickly test while developing this package, run:
-
-```bash "runbook run hello"
-npx ts-node src/cli.ts run hello --greeting Hey --name Batman
-```
-
-Alternatively, the package can be linked and run with the `DEV=true` environment variable to pick up the latest TypeScript source changes without the need to re-link the package.
-
-```bash "link"
-npm link
-DEV=true runbook run hello --greeting Hey --name Batman
-```
-
-Here's some fun - using runbook to run runbook to run the raw TypeScript version of runbook to run the "hello" command.
-
-```bash "runbook inception"
-runbook run runbook run hello
-```
-
-To run all test cases:
-
-```bash "test"
-npm run test
-```
-
-Here is a command that always fails (useful for seeing how runbook handles errors):
-
-```bash "this will fail"
-exit 1
-```
+For developing the runbook application itself, [check this out](DEVELOPERS.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,21 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      }
+    },
     "@koa/router": {
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/@koa/router/-/router-10.1.1.tgz",
@@ -53,6 +68,30 @@
         "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
       }
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
     },
     "@types/accepts": {
       "version": "1.3.5",
@@ -311,6 +350,18 @@
         "negotiator": "0.6.2"
       }
     },
+    "acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "dev": true
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
+    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -459,12 +510,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true
-    },
-    "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
     "byline": {
@@ -2807,16 +2852,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
-    "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "space-separated-tokens": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
@@ -3023,16 +3058,22 @@
       "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
     },
     "ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
       "dev": true,
       "requires": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
         "yn": "3.1.1"
       }
     },
@@ -3086,9 +3127,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -199,6 +199,16 @@
       "integrity": "sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w==",
       "dev": true
     },
+    "@types/inquirer": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-8.2.0.tgz",
+      "integrity": "sha512-BNoMetRf3gmkpAlV5we+kxyZTle7YibdOntIZbU5pyIfMdcwy784KfeZDAcuyMznkh5OLa17RVXZOGA5LTlkgQ==",
+      "dev": true,
+      "requires": {
+        "@types/through": "*",
+        "rxjs": "^7.2.0"
+      }
+    },
     "@types/keygrip": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
@@ -309,6 +319,15 @@
         "@types/node": "*"
       }
     },
+    "@types/through": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
+      "integrity": "sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/unist": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
@@ -379,6 +398,14 @@
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true
+    },
+    "ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "requires": {
+        "type-fest": "^0.21.3"
+      }
     },
     "ansi-regex": {
       "version": "5.0.1",
@@ -474,6 +501,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -488,6 +520,28 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -511,6 +565,15 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "byline": {
       "version": "5.0.0",
@@ -597,6 +660,11 @@
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
       "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
     },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -618,6 +686,24 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
       }
+    },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-spinners": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g=="
+    },
+    "cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
     },
     "cliui": {
       "version": "7.0.4",
@@ -643,6 +729,11 @@
           }
         }
       }
+    },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
     },
     "co": {
       "version": "4.6.0",
@@ -778,6 +869,14 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "requires": {
+        "clone": "^1.0.2"
+      }
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -900,8 +999,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.14.3",
@@ -944,6 +1042,16 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -996,6 +1104,14 @@
       "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
       "requires": {
         "format": "^0.2.0"
+      }
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "fill-range": {
@@ -1086,6 +1202,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "fuzzy": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/fuzzy/-/fuzzy-0.1.3.tgz",
+      "integrity": "sha1-THbsL/CsGjap3M+aAN+GIweNTtg="
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -1316,6 +1437,19 @@
         "sshpk": "^1.7.0"
       }
     },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "5.1.8",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
@@ -1334,6 +1468,211 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "inquirer": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
+      "integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.2.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
+      }
+    },
+    "inquirer-search-list": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/inquirer-search-list/-/inquirer-search-list-1.2.6.tgz",
+      "integrity": "sha512-C4pKSW7FOYnkAloH8rB4FiM91H1v08QFZZJh6KRt//bMfdDBIhgdX8wjHvrVH2bu5oIo6wYqGpzSBxkeClPxew==",
+      "requires": {
+        "chalk": "^2.3.0",
+        "figures": "^2.0.0",
+        "fuzzy": "^0.1.3",
+        "inquirer": "^3.3.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "chardet": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+          "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "cli-width": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+          "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "external-editor": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+          "requires": {
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "inquirer": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.4",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rx-lite": "^4.0.8",
+            "rx-lite-aggregates": "^4.0.8",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
     },
     "interpret": {
       "version": "1.4.0",
@@ -1440,6 +1779,11 @@
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
       "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
     },
+    "is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="
+    },
     "is-negative-zero": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
@@ -1483,8 +1827,7 @@
     "is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "dev": true
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
     },
     "isarray": {
       "version": "1.0.0",
@@ -1666,11 +2009,15 @@
         "p-locate": "^5.0.0"
       }
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "dev": true,
       "requires": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
@@ -1957,6 +2304,11 @@
         "mime-db": "1.44.0"
       }
     },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -2094,6 +2446,11 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.5"
       }
+    },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "nanoid": {
       "version": "3.2.0",
@@ -2255,6 +2612,14 @@
         "wrappy": "1"
       }
     },
+    "onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
     "only": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
@@ -2274,11 +2639,26 @@
         "word-wrap": "~1.2.3"
       }
     },
+    "ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "requires": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      }
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-is-promise": {
       "version": "3.0.0",
@@ -2760,6 +3140,15 @@
         "path-parse": "^1.0.6"
       }
     },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -2774,22 +3163,46 @@
         "glob": "^7.1.3"
       }
     },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
+    },
     "run-parallel": {
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
       "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw=="
     },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "requires": {
+        "rx-lite": "*"
+      }
+    },
+    "rxjs": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.2.tgz",
+      "integrity": "sha512-PwDt186XaL3QN5qXj/H9DGyHhP3/RYYgZZwqBv9Tv8rsAaiwFH1IsJJlcgD37J7UW5a6O67qX0KWKS3/pu0m4w==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
       "version": "5.7.1",
@@ -2841,6 +3254,11 @@
         "interpret": "^1.0.0",
         "rechoir": "^0.6.2"
       }
+    },
+    "signal-exit": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
+      "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ=="
     },
     "slash": {
       "version": "3.0.0",
@@ -2980,7 +3398,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -3028,6 +3445,19 @@
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
       "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
       "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -3116,6 +3546,11 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
+    },
+    "type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -3232,8 +3667,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "8.3.2",
@@ -3284,6 +3718,14 @@
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^2.0.0"
+      }
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "requires": {
+        "defaults": "^1.0.3"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "fs-extra": "^9.0.1",
     "globby": "^11.0.1",
     "handlebars": "^4.7.7",
+    "inquirer": "^8.2.0",
+    "inquirer-search-list": "^1.2.6",
     "koa": "^2.13.4",
     "omelette": "^0.4.17",
     "rehype-sanitize": "^4.0.0",
@@ -54,6 +56,7 @@
   "devDependencies": {
     "@types/chai": "^4.2.14",
     "@types/fs-extra": "^9.0.4",
+    "@types/inquirer": "^8.2.0",
     "@types/koa": "^2.13.4",
     "@types/koa__router": "^8.0.11",
     "@types/mocha": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "npm-run-all": "^4.1.5",
     "pkg": "^4.4.9",
     "rimraf": "^3.0.2",
-    "ts-node": "^9.1.0",
-    "typescript": "^4.1.2"
+    "ts-node": "^10.4.0",
+    "typescript": "^4.5.5"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ async function cli (args: string[]) {
   const completions = await setupCompletions()
   const command = args.shift()
   if (command === 'ls') return ls()
+  if (command === 'run' && args.length === 0) return import('./ui/run').then(ui => ui.render())
   if (command === 'run' && args.length > 0) return run(args)
   if (command === 'serve') return serve()
   if (command === 'completions') {

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -39,15 +39,15 @@ export async function ls (options = { log: true, rules: true }) {
     })))
   if (markdownFiles.length === 0) throw new ApplicationError(`No markdown files found in ${process.cwd()}`)
   if (options.rules) ensureUniqueBlockSignatures(markdownFiles)
-  const commandList = markdownFiles.reduce<Array<string>>((commandList, file) => {
+  const commands = markdownFiles.reduce<typeof markdownFiles[0]['commands']>((commands, file) => {
     file.commands.forEach(command => {
-      commandList.push(command.display)
+      commands.push(command)
     })
-    return commandList
+    return commands
   }, [])
   return {
     markdownFiles,
-    commandList
+    commands
   }
 }
 

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -57,12 +57,13 @@ export async function ls (options = { log: true, rules: true }) {
 function normalizedLang (block: { lang?: string }): string | undefined {
   if (block.lang === 'js') return 'javascript'
   if (block.lang === 'ts') return 'typescript'
+  if (block.lang === 'es6') return 'esm'
   return block.lang
 }
 
 function isSupportedBlock (params: { block: { lang?: string }}): boolean {
   const lang = normalizedLang(params.block)
-  return (lang === 'bash' || lang === 'hbs' || lang === 'javascript' || lang === 'typescript' || lang === 'python' || lang === 'go')
+  return (lang === 'bash' || lang === 'hbs' || lang === 'javascript' || lang === 'typescript' || lang ==='esm' || lang === 'python' || lang === 'go')
 }
 
 function getBlockName (params: { file: { path: string }, block: { meta?: string, position?: Position } }): string {

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -5,7 +5,9 @@ import files from '../features/files'
 import markdown from '../features/markdown'
 import handlebars from '../features/handlebars'
 import colors from '../features/colors'
+import fonts from '../features/fonts'
 import padding from '../features/padding'
+import plural from '../features/plural'
 import log from '../features/log'
 import { ApplicationError } from '../features/errors'
 
@@ -45,6 +47,7 @@ export async function ls (options = { log: true, rules: true }) {
     })
     return commands
   }, [])
+  if (options.log) log.interactive(fonts.italic(`Discovered ${colors.green(markdownFiles.length)} ${plural.s('file', markdownFiles.length)} and ${colors.green(commands.length)} ${plural.s('command', commands.length)}.`))
   return {
     markdownFiles,
     commands

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -22,7 +22,7 @@ export async function ls (options = { log: true, rules: true }) {
           const name = getBlockName({ file, block })
           const content = await getBlockContent({ file, block })
           const { args, template } = getBlockArgs({ block, content })
-          if (options.log) log.info(`${padding.for(file.path, 10, '...', ' ')} | ${colors.green(name)} ${args.map(arg => `--${arg}`).join(' ')}`)
+          if (options.log) log.info(`${padding.middle(file.path, 12, '...', ' ')} | ${colors.green(name)} ${args.map(arg => `--${arg}`).join(' ')}`)
           return {
             name,
             lang: normalizedLang(block),

--- a/src/features/completions.ts
+++ b/src/features/completions.ts
@@ -6,10 +6,10 @@ import log from '../features/log'
 import { ls } from '../commands/ls'
 
 export async function setupCompletions () {
-  const { commandList } = await ls({ log: false, rules: true })
+  const { commands } = await ls({ log: false, rules: true })
   const completion = omelette('runbook|r').tree({
     'ls': {},
-    'run': tree(commandList, ' '),
+    'run': tree(commands.map(command => command.display), ' '),
     'serve': {},
     'completions': {
       'set': {},

--- a/src/features/fonts.ts
+++ b/src/features/fonts.ts
@@ -1,0 +1,7 @@
+import { italic } from 'chalk'
+
+export const fonts = {
+  italic
+}
+
+export default fonts

--- a/src/features/padding.ts
+++ b/src/features/padding.ts
@@ -1,22 +1,40 @@
 export const padding = {
   /**
+   * Adds the padding character to the end of the string N times.
+   */
+  padEnd: (text: string, paddingCharacter: string, times: number): string => {
+    let newText = text
+    for (let i = 0; i < times; i++) {
+      newText += paddingCharacter[0]
+    }
+    return newText
+  },
+  /**
    * Adds padding to the end of text,
    * or adds a prefix to the beginning and removes text,
    * to return a string with length equal to the expected length.
    */
-  for: (text: string, expectedLength: number, prefix: string, paddingCharacter: string) => {
+  prefix: (text: string, expectedLength: number, prefix: string, paddingCharacter: string): string => {
     const difference = text.length - expectedLength
     const isShorter = difference < 0
     const isLonger = difference > 0
-    if (isShorter) {
-      let newText = text
-      for (let i = 0; i < Math.abs(difference); i++) {
-        newText += paddingCharacter[0]
-      }
-      return newText
-    }
+    if (isShorter) return padding.padEnd(text, paddingCharacter, Math.abs(difference))
+    if (isLonger) return prefix + text.substring(prefix.length + difference)
+    return text
+  },
+  /**
+   * Adds padding to the end of text,
+   * or replaces the middle of the text with the provided string,
+   * to return a string with length equal to the expected length.
+   */
+  middle: (text: string, expectedLength: number, middle: string, paddingCharacter: string): string => {
+    const difference = text.length - expectedLength
+    const isShorter = difference < 0
+    const isLonger = difference > 0
+    if (isShorter) return padding.padEnd(text, paddingCharacter, Math.abs(difference))
     if (isLonger) {
-      return prefix + text.substring(prefix.length + difference)
+      const center = Math.floor((text.length - middle.length - difference) / 2)      
+      return text.substring(0, center) + middle + text.substring(center + middle.length + difference)
     }
     return text
   }

--- a/src/features/plural.ts
+++ b/src/features/plural.ts
@@ -1,0 +1,10 @@
+export const plural = {
+  form (singular: string, plural: string, actual: number) {
+    return (actual === 1) ? singular : plural
+  },
+  s (singular: string, actual: number) {
+    return plural.form(singular, singular + 's', actual)
+  }
+}
+
+export default plural

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from 'mocha'
 import { expect } from 'chai'
 
 import padding from './features/padding'
+import plural from './features/plural'
 import tree from './features/tree'
 
 import { ls } from './commands/ls'
@@ -78,6 +79,22 @@ describe('runbook', () => {
         expect(padded).to.deep.equal(text)
       })
 
+    })
+
+  })
+
+  describe('feature | plural', () => {
+
+    it('shows the correct singular text', async () => {
+      expect(plural.form('person', 'people', 1)).to.deep.equal('person')
+      expect(plural.s('team', 1)).to.deep.equal('team')
+    })
+
+    it('shows the correct plural text', () => {
+      expect(plural.form('person', 'people', 0)).to.deep.equal('people')
+      expect(plural.form('person', 'people', 2)).to.deep.equal('people')
+      expect(plural.s('team', 0)).to.deep.equal('teams')
+      expect(plural.s('team', 2)).to.deep.equal('teams')
     })
 
   })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -19,7 +19,7 @@ describe('runbook', () => {
     it('can list commands', async () => {
       const { markdownFiles, commands } = await ls({ log: false, rules: true })
       const commandsFound = markdownFiles.flatMap(file => file.commands)
-      expect(commandsFound.length).to.deep.equal(15)
+      expect(commandsFound.length).to.deep.equal(20)
       expect(commandsFound.length).to.deep.equal(commands.length)
     })
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -16,10 +16,10 @@ describe('runbook', () => {
     })
   
     it('can list commands', async () => {
-      const { markdownFiles, commandList } = await ls({ log: false, rules: true })
-      const commands = markdownFiles.flatMap(file => file.commands)
-      expect(commands.length).to.deep.equal(15)
-      expect(commands.length).to.deep.equal(commandList.length)
+      const { markdownFiles, commands } = await ls({ log: false, rules: true })
+      const commandsFound = markdownFiles.flatMap(file => file.commands)
+      expect(commandsFound.length).to.deep.equal(15)
+      expect(commandsFound.length).to.deep.equal(commands.length)
     })
 
   })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -12,7 +12,7 @@ describe('runbook', () => {
 
     it('can list files', async () => {
       const { markdownFiles } = await ls({ log: false, rules: true })
-      expect(markdownFiles.length).to.deep.equal(2)
+      expect(markdownFiles.length).to.deep.equal(4)
     })
   
     it('can list commands', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -26,27 +26,58 @@ describe('runbook', () => {
 
   describe('feature | padding', () => {
 
-    it('can pad text if shorter', async () => {
-      const text = 'hello'
-      const expectedLength = 10
-      const padded = padding.for(text, expectedLength, '...', ' ')
-      expect(padded).to.deep.equal('hello     ')
-      expect(padded.length).to.deep.equal(expectedLength)
+    describe('prefix', () => {
+
+      it('can pad text if shorter', async () => {
+        const text = 'hello'
+        const expectedLength = 10
+        const padded = padding.prefix(text, expectedLength, '...', ' ')
+        expect(padded).to.deep.equal('hello     ')
+        expect(padded.length).to.deep.equal(expectedLength)
+      })
+
+      it('can prefix text if longer', async () => {
+        const text = '/some/really/long/path'
+        const expectedLength = 10
+        const padded = padding.prefix(text, expectedLength, '...', ' ')
+        expect(padded).to.deep.equal('...ng/path')
+        expect(padded.length).to.deep.equal(expectedLength)
+      })
+
+      it('returns original text if already at expected length', async () => {
+        const text = 'goodbye'
+        const expectedLength = text.length
+        const padded = padding.prefix(text, expectedLength, '...', ' ')
+        expect(padded).to.deep.equal(text)
+      })
+
     })
 
-    it('can prefix text if longer', async () => {
-      const text = '/some/really/long/path'
-      const expectedLength = 10
-      const padded = padding.for(text, expectedLength, '...', ' ')
-      expect(padded).to.deep.equal('...ng/path')
-      expect(padded.length).to.deep.equal(expectedLength)
-    })
+    describe('middle', () => {
 
-    it('returns original text if already at expected length', async () => {
-      const text = 'goodbye'
-      const expectedLength = text.length
-      const padded = padding.for(text, expectedLength, '...', ' ')
-      expect(padded).to.deep.equal(text)
+      it('can pad text if shorter', async () => {
+        const text = 'hello'
+        const expectedLength = 10
+        const padded = padding.middle(text, expectedLength, '...', ' ')
+        expect(padded).to.deep.equal('hello     ')
+        expect(padded.length).to.deep.equal(expectedLength)
+      })
+
+      it('can replace middle text if longer', async () => {
+        const text = '/some/really/long/path'
+        const expectedLength = 10
+        const padded = padding.middle(text, expectedLength, '...', ' ')
+        expect(padded).to.deep.equal('/so...path')
+        expect(padded.length).to.deep.equal(expectedLength)
+      })
+
+      it('returns original text if already at expected length', async () => {
+        const text = 'goodbye'
+        const expectedLength = text.length
+        const padded = padding.middle(text, expectedLength, '...', ' ')
+        expect(padded).to.deep.equal(text)
+      })
+
     })
 
   })

--- a/src/ui/run.ts
+++ b/src/ui/run.ts
@@ -1,0 +1,42 @@
+import inquirer from 'inquirer'
+
+import colors from '../features/colors'
+import log from '../features/log'
+
+import { ls } from '../commands/ls'
+import { run } from '../commands/run'
+
+export async function render () {
+  console.clear()
+  inquirer.registerPrompt('search-list', require('inquirer-search-list'))
+  const { commands } = await ls({ log: false, rules: true })
+  return inquirer
+  .prompt<{ command: string[] }>([
+    {
+      type: 'search-list',
+      message: 'Select a command to run',
+      name: 'command',
+      choices: commands.map(command => ({ name: command.display, value: [command.name, ...command.args] })),
+      validate: function (answer) {
+        return true
+      }
+    }
+  ])
+  .then(async (answers) => {
+    const args: string[] = [ answers.command[0] ]
+    for (let arg = 1; arg < answers.command.length; arg++) {
+      const answer = await inquirer.prompt<{ arg: string }>({
+        type: 'input',
+        message: `Enter a value for ${colors.green(`--${answers.command[arg]}`)}`,
+        name: 'arg',
+        validate: function (input, answers) {
+          return input ? true : false
+        }
+      })
+      args.push(`--${answers.command[arg]}`)
+      args.push(answer.arg)
+    }
+    log.interactive('> ' + colors.green(args.join(' ')))
+    return run(args)
+  })
+}


### PR DESCRIPTION
### Fixes

- Updating count in test to reflect the current number of markdown files
- Instead of a string-only command list, returning a list of command objects
- For `runbook ls`, shortening the middle of the file name instead of using a prefix
- Increasing image width for screenshot
- Moving developer docs for the runbook application itself to its own file

### Features

- Adding an interactive menu for selecting a command to run, and providing args
- Adding a message that shows how many files and commands were discovered
- Adding support for es6 with esm
- Upgrading typescript and ts-node
- Adding the first few useful scripts to the library doc
