### PR TITLE
Changes for v0.7.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1

--- a/USAGE.md
+++ b/USAGE.md
@@ -67,6 +67,7 @@ Currently, `runbook run` supports the execution of `bash`, `powershell`, `javasc
 - `powershell` and `ps1` blocks are executed with `pwsh` or `powershell.exe`
 - `javascript` and `js` blocks are executed with `node`
 - `typescript` and `ts` blocks are executed with `npx ts-node`
+- `esm` and `es6` blocks are executed with `node --loader ts-node/esm`
 - `python` blocks are executed with `python`
 - `go` blocks are executed with `go`
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -61,9 +61,10 @@ func main() {
 
 ## supported runtimes
 
-Currently, `runbook run` supports the execution of `bash`, `javascript`, `typescript`, `python`, and `go` blocks. Other blocks are ignored.
+Currently, `runbook run` supports the execution of `bash`, `powershell`, `javascript`, `typescript`, `python`, and `go` blocks. Other blocks are ignored.
 
 - `bash` blocks are executed with `bash`
+- `powershell` and `ps1` blocks are executed with `pwsh` or `powershell.exe`
 - `javascript` and `js` blocks are executed with `node`
 - `typescript` and `ts` blocks are executed with `npx ts-node`
 - `python` blocks are executed with `python`

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -55,6 +55,7 @@ export async function ls (options = { log: true, rules: true }) {
 }
 
 function normalizedLang (block: { lang?: string }): string | undefined {
+  if (block.lang === 'ps1') return 'powershell'
   if (block.lang === 'js') return 'javascript'
   if (block.lang === 'ts') return 'typescript'
   if (block.lang === 'es6') return 'esm'
@@ -63,7 +64,7 @@ function normalizedLang (block: { lang?: string }): string | undefined {
 
 function isSupportedBlock (params: { block: { lang?: string }}): boolean {
   const lang = normalizedLang(params.block)
-  return (lang === 'bash' || lang === 'hbs' || lang === 'javascript' || lang === 'typescript' || lang ==='esm' || lang === 'python' || lang === 'go')
+  return (lang === 'bash' || lang === 'hbs' || lang === 'powershell' || lang === 'javascript' || lang === 'typescript' || lang === 'esm' || lang === 'python' || lang === 'go')
 }
 
 function getBlockName (params: { file: { path: string }, block: { meta?: string, position?: Position } }): string {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -19,7 +19,7 @@ describe('runbook', () => {
     it('can list commands', async () => {
       const { markdownFiles, commands } = await ls({ log: false, rules: true })
       const commandsFound = markdownFiles.flatMap(file => file.commands)
-      expect(commandsFound.length).to.deep.equal(20)
+      expect(commandsFound.length).to.deep.equal(22)
       expect(commandsFound.length).to.deep.equal(commands.length)
     })
 


### PR DESCRIPTION
### Fixes

- Adding the missing docs for the `esm` runtime
- Fixing branch name in Github Actions workflow
- Updating array of supported node versions for test (v12, v14, v16 Node.js LTS versions)
- Updating count in test to reflect the current number of commands

### Features

- Adding support for running powershell blocks
